### PR TITLE
Audit and harden project sanity

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.env
+.env.*
+__pycache__/
+*.py[cod]
+*.log
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+build/
+built/
+dist/
+*.egg-info/
+tests/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM python:3.8-slim-buster
+FROM python:3.9-slim-bookworm
 
 WORKDIR /app
 
 COPY . .
 
-RUN apt-get update
-RUN apt-get install -y make gcc python3-dev libproj-dev libgeos-dev libeccodes-dev libeccodes-tools
-RUN pip install -r requirements/dev-container.txt
-RUN pip install .
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends make gcc python3-dev libproj-dev libgeos-dev libeccodes-dev libeccodes-tools \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir -c requirements/constraints-py39.txt -r requirements/dev-container.txt
+RUN pip install --no-cache-dir -c requirements/constraints-py39.txt .
+
+RUN useradd --create-home --shell /bin/bash gdio \
+    && chown -R gdio:gdio /app
+USER gdio
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SERVICE=gdio
 DOCKERCOMPOSE=docker-compose -f docker-compose.yml -f docker-compose.dev.yml
+CONSTRAINTS=requirements/constraints-py39.txt
 
 build: # Build the container, before up and when you change the dockerfile
 	$(DOCKERCOMPOSE) build
@@ -26,12 +27,12 @@ fix: # Run autopep to fix code format
 	$(DOCKERCOMPOSE) exec $(SERVICE) autopep8 --in-place -a --max-line-length 120 -r .
 
 clean: # clean images
-	$(DOCKERCOMPOSE) stop && docker image rm $(docker images 'gdio_gdio' -a -q)
+	$(DOCKERCOMPOSE) down --rmi local
 
 # Out of the container
 
 tests-local:
-	pip python -m unittest discover tests/
+	python -m unittest discover -s tests -p "test_*.py"
 
 fix-local:
 	autopep8 --in-place -a --max-line-length 120 -r .
@@ -39,6 +40,7 @@ fix-local:
 dev-requirements:
 	pip install -r requirements/dev.txt
 
-
+dev-requirements-locked:
+	pip install -c $(CONSTRAINTS) -r requirements/dev.txt
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ conda install -c rodri90y gdio
 
 if you are using pip install, before install manually the requirements
 
-conda create -n envname --file requirements/base.txt
+conda create -n envname python=3.9 --file requirements/base.txt
 pip install gdio
 or
 pip install --index-url https://test.pypi.org/simple/ --upgrade --no-cache-dir --extra-index-url=https://pypi.org/simple/ gdio
@@ -40,7 +40,12 @@ conda config --add channels conda-forge
 
 #### Testing
 ```
-python -m unittest 
+python -m unittest discover -s tests -p "test_*.py"
+```
+
+For reproducible pip installs in the Python 3.9 container/test environment, use the constraints file:
+```
+pip install -c requirements/constraints-py39.txt -r requirements/dev.txt
 ```
 
 

--- a/gdio/cgrib.py
+++ b/gdio/cgrib.py
@@ -1,10 +1,9 @@
+import eccodes
 import numpy as np
 import pyproj
 from eccodes import *
 from .definitions.grib_namespace import *
 from .definitions.Table_4_5 import TYPE_LEVEL
-
-from datetime import datetime, timedelta
 
 class cgrib():
 
@@ -446,7 +445,7 @@ class fwrite():
             message["iScansNegatively"] = lon_scan_negatively
             message["jScansNegatively"] = lat_scan_negatively
 
-        elif self['gridType'] == 'mercator':
+        elif message['gridType'] == 'mercator':
 
             message['Ni'] = nx
             message['Nj'] = ny
@@ -471,7 +470,7 @@ class fwrite():
             message['LaD'] = lat_ts * 1000
 
 
-        elif self['gridType'] == 'lambert':
+        elif message['gridType'] == 'lambert':
 
             message['Ni'] = nx
             message['Nj'] = ny
@@ -499,7 +498,7 @@ class fwrite():
             # x, y = np.meshgrid(x, y)
             # lons, lats = pj(x, y, inverse=True)
 
-            raise ValueError('unsupported grid {0}'.format(self['gridType']))
+            raise ValueError('unsupported grid {0}'.format(message['gridType']))
         else:
             #detect the data grig projection
             pass

--- a/gdio/commons.py
+++ b/gdio/commons.py
@@ -1,10 +1,52 @@
-import copy
 import difflib
-import os
 import numpy as np
 import itertools
 
 from datetime import datetime, timedelta
+
+
+MINUTES_PER_HOUR = 60
+HOURS_PER_DAY = 24
+DAYS_PER_MONTH = 30
+DAYS_PER_YEAR = 365
+
+TIME_UNIT_HOURS = {
+    'second': 1 / (MINUTES_PER_HOUR * MINUTES_PER_HOUR),
+    'seconds': 1 / (MINUTES_PER_HOUR * MINUTES_PER_HOUR),
+    'minute': 1 / MINUTES_PER_HOUR,
+    'minutes': 1 / MINUTES_PER_HOUR,
+    'hour': 1,
+    'hours': 1,
+    'hrs': 1,
+    'day': HOURS_PER_DAY,
+    'days': HOURS_PER_DAY,
+    'month': HOURS_PER_DAY * DAYS_PER_MONTH,
+    'months': HOURS_PER_DAY * DAYS_PER_MONTH,
+    'year': HOURS_PER_DAY * DAYS_PER_YEAR,
+    'years': HOURS_PER_DAY * DAYS_PER_YEAR,
+}
+
+
+def time_unit_to_hours(unit):
+    """
+    Convert supported time-unit labels to their scale in hours.
+    """
+    return TIME_UNIT_HOURS.get(str(unit).lower(), unit)
+
+
+def parse_time_units(units):
+    """
+    Parse strings like "hours since 2019-12-27 00:00".
+    """
+    import re
+
+    pattern = re.compile(r"(.*?) since (?P<year>\d{4})\-(\d{1,2})\-(\d{1,2})\s+(\d{1,2})?\:*(\d{1,2})?")
+    result = re.findall(pattern, str(units))
+
+    if result:
+        return result[0][0], datetime(*[int(item) for item in result[0][1:]])
+
+    return None, None
 
 
 class objectify(dict):
@@ -296,4 +338,3 @@ def __data_tree(data, depth=0):
                                                              key=k,
                                                              value=str(v))
                      )
-

--- a/gdio/core.py
+++ b/gdio/core.py
@@ -11,20 +11,17 @@ __description__ = "A simple and concise gridded data IO library for read multipl
 import copy
 import logging
 import multiprocessing
-import os, sys
-import warnings
-from datetime import datetime, timedelta
+import os
+from datetime import datetime
 from functools import partial
 
 import numpy as np
 import numpy.ma as ma
 
-from gdio.commons import near_yx2, objectify, show_data_structure, timestep_to_datetime
+from gdio.commons import near_yx2, objectify, show_data_structure, time_unit_to_hours, timestep_to_datetime
 from gdio.grib import grib as gblib
 from gdio.netcdf import netcdf as nclib
 from gdio.hdf import hdf as hdlib
-
-warnings.filterwarnings("ignore")
 
 
 class gdio(object):
@@ -65,8 +62,8 @@ class gdio(object):
                cut_time=None,
                cut_domain=None,
                level_type=None,
-               filter_by={},
-               rename_vars={},
+               filter_by=None,
+               rename_vars=None,
                sort_before=False):
         '''
         Load and cutting function
@@ -94,6 +91,9 @@ class gdio(object):
                                     when the grib data structure is not standard
         :return:                    dictionary
         '''
+
+        filter_by = {} if filter_by is None else filter_by
+        rename_vars = {} if rename_vars is None else rename_vars
 
         if os.path.isfile(ifile):
 
@@ -145,10 +145,10 @@ class gdio(object):
               cut_time=None,
               cut_domain=None,
               level_type=None,
-              filter_by={},
+              filter_by=None,
               uniformize_grid=True,
               sort_before=False,
-              rename_vars={},
+              rename_vars=None,
               inplace=False):
         '''
         Load multiple grib/netcdf files
@@ -181,6 +181,9 @@ class gdio(object):
         :return:                    list of dictionaries
         '''
 
+        filter_by = {} if filter_by is None else filter_by
+        rename_vars = {} if rename_vars is None else rename_vars
+
         data = objectify()
         griddes = ()
         ntimes = 1
@@ -193,20 +196,21 @@ class gdio(object):
         level_type = level_type if level_type is None else list(level_type)
         self.variables = list()
 
-        pool = multiprocessing.Pool(processes=self.remap_n_processes)
-
         if isinstance(files, str):
             files = [files]
 
-        for _dat in pool.map(
-                partial(self.thread, vars=vars,
-                        cut_time=cut_time,
-                        cut_domain=cut_domain,
-                        level_type=level_type,
-                        filter_by=filter_by,
-                        rename_vars=rename_vars,
-                        sort_before=sort_before),
-                files):
+        with multiprocessing.Pool(processes=self.remap_n_processes) as pool:
+            loaded_files = pool.map(
+                    partial(self.thread, vars=vars,
+                            cut_time=cut_time,
+                            cut_domain=cut_domain,
+                            level_type=level_type,
+                            filter_by=filter_by,
+                            rename_vars=rename_vars,
+                            sort_before=sort_before),
+                    files)
+
+        for _dat in loaded_files:
 
             if vars is not None:
                 vars = [rename_vars.get(n, n) for n in vars]
@@ -222,22 +226,7 @@ class gdio(object):
                         lons_n, lats_n = self.__get_lonlat(_dat, vars)
                         griddes = lats_n.shape
 
-                    # convert to day unity
-                    t_units = _dat.get('time_units').lower()
-
-                    # continue
-                    if t_units in ['second', 'seconds']:
-                        t_units = 1 / 3600
-                    elif t_units in ['minute', 'minutes']:
-                        t_units = 1 / 60
-                    elif t_units in ['hour', 'hours', 'hrs']:
-                        t_units = 1
-                    elif t_units in ['day', 'days']:
-                        t_units = 24
-                    elif t_units in ['month', 'months']:
-                        t_units = 24 * 30
-                    elif t_units in ['year', 'years']:
-                        t_units = 24 * 24 * 365
+                    t_units = time_unit_to_hours(_dat.get('time_units'))
 
                     if (vars is None or key in vars) \
                             and not key in ['latitude', 'longitude', 'ref_time', 'time', 'time_units']:
@@ -338,7 +327,7 @@ class gdio(object):
                             or key in self.__fields_time
                             or key in self.__fields_level
                             or key in ['ref_time', 'time_units']):
-                        for typLev in val.level_type:
+                        for typLev in data[key].level_type:
                             # usar t_units e shape do dado ultimo arquivo
 
                             data[key][typLev].value = np.concatenate((data[key][typLev].value,
@@ -375,8 +364,6 @@ class gdio(object):
                 self.dataset.append(data)
         else:
             return data
-
-        pool.terminate()
 
 
 
@@ -542,16 +529,14 @@ class gdio(object):
 
         n_processes = cpu_num if self.remap_n_processes > cpu_num else self.remap_n_processes
 
-        pool = multiprocessing.Pool(processes=n_processes)
-
         # here we parallelise in each step of time, a kind of magic
-        _data = np.array(pool.map(
-            partial(self.interp, xin=lon[np.argsort(lon)],
-                    yin=lat[np.argsort(lat)], xout=_lon_new, yout=_lat_new,
-                    order=order, masked=masked),
-            data)
-        )
-        pool.close()
+        with multiprocessing.Pool(processes=n_processes) as pool:
+            _data = np.array(pool.map(
+                partial(self.interp, xin=lon[np.argsort(lon)],
+                        yin=lat[np.argsort(lat)], xout=_lon_new, yout=_lat_new,
+                        order=order, masked=masked),
+                data)
+            )
 
         return _data
 

--- a/gdio/definitions/grib_namespace.py
+++ b/gdio/definitions/grib_namespace.py
@@ -39,7 +39,7 @@ DATA_TIME_KEYS = [
     "stepRange",
     "step",
     "validityDate",
-    "validityTime"
+    "validityTime",
     "unitOfTimeRange",
     "year",
     "month",

--- a/gdio/grib.py
+++ b/gdio/grib.py
@@ -10,11 +10,10 @@ __description__ = "A grib file IO library"
 
 import logging
 from datetime import datetime, timedelta
-import os
 import numpy as np
 
 from gdio import cgrib
-from gdio.commons import near_yx2, objectify, dict_get, timestep_to_datetime, datetime_to_timestep
+from gdio.commons import near_yx2, objectify, dict_get, timestep_to_datetime
 from .definitions.Table_4_4 import UNIT_TIME_RANGE
 
 class grib(object):
@@ -64,8 +63,8 @@ class grib(object):
                 level_type=None,
                 cut_time=None,
                 cut_domain=None,
-                filter_by={},
-                rename_vars={},
+                filter_by=None,
+                rename_vars=None,
                 sort_before=False):
         '''
         Load grib file
@@ -97,6 +96,9 @@ class grib(object):
 
         _data = objectify()
         data = objectify()
+
+        filter_by = {} if filter_by is None else filter_by
+        rename_vars = {} if rename_vars is None else rename_vars
 
         # fix parameters types
         vars = vars if vars is None else list(vars)
@@ -146,7 +148,7 @@ class grib(object):
                             if not forecastDate == self.fcstTime(gr):
                                 concat_time = True
                                 forecastDate = self.fcstTime(gr)
-                                fcst_time = int((forecastDate - ref_time).total_seconds() / (self.__unity(gr) * 3600))
+                                fcst_time = self.__forecast_step(forecastDate, ref_time, gr.stepUnits)
                                 step_time += 1
                                 member_num = 0
 
@@ -524,6 +526,9 @@ class grib(object):
             scale = 10 * 24 * 365
 
         return scale
+
+    def __forecast_step(self, forecast_date, ref_time, step_units):
+        return int((forecast_date - ref_time).total_seconds() / (self.__unity(step_units) * 3600))
 
 
     def __concat_time(self, _data, __data, fcst_time=None):

--- a/gdio/hdf.py
+++ b/gdio/hdf.py
@@ -9,13 +9,12 @@ __status__ = "development"
 __description__ = "A netcdf file IO library"
 
 import logging
-import re
 from datetime import datetime
 
 import numpy as np
 import h5py
 
-from gdio.commons import near_yx2, objectify, near_yx
+from gdio.commons import near_yx2, objectify, parse_time_units
 
 
 class hdf(object):
@@ -95,7 +94,15 @@ class hdf(object):
 
     def h5py_dataset_iterator(self, node):
 
-        for key, item in node.items():
+        for key in node.keys():
+            link = node.get(key, getlink=True)
+
+            if isinstance(link, h5py.ExternalLink):
+                logging.warning('''gdio.hdf_load > ignoring external HDF5 link: {0}'''.format(key))
+                continue
+
+            item = node.get(key)
+
             if isinstance(item, h5py.Dataset):  # test for dataset
                 yield (key, item)
             elif isinstance(item, h5py.Group):  # test for group (go down)
@@ -106,7 +113,7 @@ class hdf(object):
                 cut_time=None,
                 cut_domain=None,
                 level_type=None,
-                rename_vars={}):
+                rename_vars=None):
         '''
         Load netcdf files
         Rodrigo Yamamoto @ Set.2022
@@ -129,6 +136,8 @@ class hdf(object):
         '''
 
         data = objectify()
+        _hf = None
+        rename_vars = {} if rename_vars is None else rename_vars
 
         try:
             _hf = h5py.File(ifile, mode='r')
@@ -318,10 +327,11 @@ class hdf(object):
                 elif key in self.__fields_time:
                     data.update({key: self.time[start:stop]})
 
-            _hf.close()
-
         except Exception as e:
             logging.error('''gdio.hdf_load > {0}'''.format(e))
+        finally:
+            if _hf is not None:
+                _hf.close()
 
         return data
 
@@ -331,7 +341,7 @@ class hdf(object):
                  complevel=9,
                  least_significant_digit=None,
                  force_reg_grid=True,
-                 global_atrib={}
+                 global_atrib=None
                  ):
         '''
         Write HDF file
@@ -358,6 +368,7 @@ class hdf(object):
 
         #TODO: verificar padrão para gravar o time ref, data de referencia não aparece no ncview
 
+        global_atrib = {} if global_atrib is None else global_atrib
         _hf = h5py.File(ifile, mode='w')
 
         # settings
@@ -594,13 +605,7 @@ class hdf(object):
 
         units = units if units is not None else self.time_units
 
-        padrao = re.compile("(.*?) since (?P<ano>\\d{4})\\-(\\d{1,2})\\-(\\d{1,2})\\s+(\\d{1,2})?\\:*(\\d{1,2})?")
-        result = re.findall(padrao, str(units))
-
-        if result:
-            return result[0][0], datetime(*[int(item) for item in result[0][1:]])
-        else:
-            return None, None
+        return parse_time_units(units)
 
 
 

--- a/gdio/netcdf.py
+++ b/gdio/netcdf.py
@@ -9,13 +9,12 @@ __status__ = "development"
 __description__ = "A netcdf file IO library"
 
 import logging
-import re
 from datetime import datetime
 
 import numpy as np
 from netCDF4 import Dataset
 
-from gdio.commons import near_yx2, objectify, near_yx
+from gdio.commons import near_yx2, objectify, parse_time_units
 
 
 class netcdf(object):
@@ -90,7 +89,7 @@ class netcdf(object):
                 cut_time=None,
                 cut_domain=None,
                 level_type=None,
-                rename_vars={}):
+                rename_vars=None):
         '''
         Load netcdf files
         Rodrigo Yamamoto @ Fev.2021, Carlos Silva
@@ -113,6 +112,8 @@ class netcdf(object):
         '''
 
         data = objectify()
+        _nc = None
+        rename_vars = {} if rename_vars is None else rename_vars
 
         try:
 
@@ -287,10 +288,11 @@ class netcdf(object):
                 elif key in self.__fields_time:
                     data.update({key: self.time[start:stop]})
 
-            _nc.close()
-
         except Exception as e:
             logging.error('''gdio.nc_load > {0}'''.format(e))
+        finally:
+            if _nc is not None:
+                _nc.close()
 
         return data
 
@@ -322,7 +324,7 @@ class netcdf(object):
                  complevel=4,
                  least_significant_digit=None,
                  force_reg_grid=True,
-                 global_atrib={}
+                 global_atrib=None
                  ):
         '''
         Write netcdf file
@@ -350,6 +352,7 @@ class netcdf(object):
         :return:
         '''
 
+        global_atrib = {} if global_atrib is None else global_atrib
         _nc = Dataset(ifile, mode='w', format=netcdf_format)
 
         # settings
@@ -519,7 +522,7 @@ class netcdf(object):
                                 ncvar = _nc.createVariable(key, "f4",
                                                            sorted(dims + z_dims,
                                                                   key=lambda d: self.__fields_order.index(d)),
-                                                           zlib=True,
+                                                           zlib=zlib,
                                                            complevel=complevel,
                                                            least_significant_digit=least_significant_digit)
 
@@ -559,13 +562,7 @@ class netcdf(object):
 
         units = units if units is not None else self.time_units
 
-        padrao = re.compile("(.*?) since (?P<ano>\\d{4})\\-(\\d{1,2})\\-(\\d{1,2})\\s+(\\d{1,2})?\\:*(\\d{1,2})?")
-        result = re.findall(padrao, str(units))
-
-        if result:
-            return result[0][0], datetime(*[int(item) for item in result[0][1:]])
-        else:
-            return None, None
+        return parse_time_units(units)
 
     @staticmethod
     def is_netcdf(ifile):
@@ -577,6 +574,7 @@ class netcdf(object):
         '''
 
         if isinstance(ifile, str):
+            _nc = None
             try:
                 _nc = Dataset(ifile, mode='r')
 
@@ -586,5 +584,8 @@ class netcdf(object):
 
             except:
                 return False
+            finally:
+                if _nc is not None:
+                    _nc.close()
 
         return False

--- a/meta.yaml
+++ b/meta.yaml
@@ -14,7 +14,7 @@ requirements:
   build:
     - {{ compiler('c') }}      # Necessário se houver extensões C
   host:
-    - python=3.9.0
+    - python >=3.9
     - pip
     - setuptools
     - hdf5 >=1.12              # Fixa a versão para evitar o erro de símbolo
@@ -22,7 +22,7 @@ requirements:
     - h5py >=3.6.0
     - eccodes >=2.25.0
   run:
-    - python=3.9.0
+    - python >=3.9
     - hdf5                     # Garante que a lib de sistema seja instalada
     - netcdf4 >=1.5.8
     - h5py >=3.6.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,6 @@
-python>=3.9.0
 numpy>=1.21.5
 eccodes>=2.25.20
 netCDF4>=1.5.8
 h5py>=3.6.0
 pyproj
-python-eccodes>=1.4.0
 scipy

--- a/requirements/constraints-py39.txt
+++ b/requirements/constraints-py39.txt
@@ -1,0 +1,46 @@
+# Reproducible pip constraints for the Python 3.9 container/test environment.
+# Keep requirements/*.txt as the flexible developer input; use this file with
+# `pip install -c requirements/constraints-py39.txt ...` when deterministic
+# builds are needed.
+#
+# Last verified with:
+#   Python 3.9.25
+#   python -m unittest discover -s tests -p "test_*.py"
+
+asttokens==3.0.1
+attrs==26.1.0
+autopep8==1.6.0
+certifi==2026.5.20
+cffi==2.0.0
+cftime==1.6.4.post1
+decorator==5.3.1
+eccodes==2.42.0
+exceptiongroup==1.3.1
+executing==2.2.1
+findlibs==0.1.2
+h5py==3.14.0
+iniconfig==2.1.0
+ipython==8.18.1
+jedi==0.19.2
+matplotlib-inline==0.2.2
+netCDF4==1.7.2
+numpy==1.22.0
+packaging==26.2
+parso==0.8.7
+pexpect==4.9.0
+pluggy==1.6.0
+prompt-toolkit==3.0.52
+ptyprocess==0.7.0
+pure-eval==0.2.3
+pycodestyle==2.14.0
+pycparser==2.23
+Pygments==2.20.0
+pyproj==3.6.1
+pytest==8.4.2
+scipy==1.11.4
+stack-data==0.6.3
+toml==0.10.2
+tomli==2.4.1
+traitlets==5.15.1
+typing-extensions==4.15.0
+wcwidth==0.8.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,5 @@
-python>=3.9.0
 numpy>=1.21.5
 eccodes>=2.24.2
-python-eccodes>=1.4.0
 netCDF4>=1.5.8
 pyproj
 scipy

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='==3.9.0',
+    python_requires='>=3.9',
     install_requires=['numpy', 'netCDF4', 'h5py', 'eccodes', 'pyproj'],
 )

--- a/tests/test_cgrib.py
+++ b/tests/test_cgrib.py
@@ -1,0 +1,92 @@
+import importlib
+import sys
+import types
+import unittest
+
+
+class TestCgribWriter(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._sentinel = object()
+        cls._module_names = ['eccodes', 'numpy', 'pyproj', 'gdio.cgrib']
+        cls._saved_modules = {
+            name: sys.modules.get(name, cls._sentinel)
+            for name in cls._module_names
+        }
+
+        for name in cls._module_names:
+            sys.modules.pop(name, None)
+
+        fake_eccodes = types.ModuleType('eccodes')
+        fake_eccodes.CODES_PRODUCT_GRIB = 1
+        fake_eccodes.KeyValueNotFoundError = type('KeyValueNotFoundError', (Exception,), {})
+        fake_eccodes.ArrayTooSmallError = type('ArrayTooSmallError', (Exception,), {})
+        fake_numpy = types.ModuleType('numpy')
+        fake_pyproj = types.ModuleType('pyproj')
+
+        for name in [
+            'codes_get_native_type',
+            'codes_get_string',
+            'codes_get_double',
+            'codes_get_array',
+            'codes_get',
+            'codes_get_values',
+            'codes_get_message',
+            'codes_count_in_file',
+            'codes_clone',
+            'codes_set',
+            'codes_set_values',
+            'codes_grib_new_from_file',
+            'codes_release',
+            'codes_write',
+            'codes_new_from_samples',
+        ]:
+            setattr(fake_eccodes, name, lambda *args, **kwargs: None)
+
+        sys.modules['eccodes'] = fake_eccodes
+        sys.modules['numpy'] = fake_numpy
+        sys.modules['pyproj'] = fake_pyproj
+        cls.cgrib = importlib.import_module('gdio.cgrib')
+
+    @classmethod
+    def tearDownClass(cls):
+        for name in cls._module_names:
+            sys.modules.pop(name, None)
+
+            original = cls._saved_modules[name]
+            if original is not cls._sentinel:
+                sys.modules[name] = original
+
+    def test_writer_uses_message_grid_type_for_mercator_projection(self):
+        writer = self.cgrib.fwrite.__new__(self.cgrib.fwrite)
+        message = {
+            'gridType': 'mercator',
+            'value': FakeGrid([[0.0, 0.0], [0.0, 0.0]]),
+            'longitude': FakeGrid([[10.0, 11.0], [10.0, 11.0]]),
+            'latitude': FakeGrid([[0.0, 0.0], [1.0, 1.0]]),
+        }
+
+        self.cgrib.fwrite._fwrite__set_grib_proj_keys(writer, message)
+
+        self.assertEqual(message['Ni'], 2)
+        self.assertEqual(message['Nj'], 2)
+        self.assertIn('LaD', message)
+
+
+class FakeGrid:
+
+    def __init__(self, values):
+        self.values = values
+        self.shape = (len(values), len(values[0]))
+
+    def __getitem__(self, index):
+        if isinstance(index, tuple):
+            row, col = index
+            return self.values[row][col]
+
+        return self.values[index]
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,15 +47,15 @@ class TestNcFiles(unittest.TestCase):
         self.expected_sel = (1, 1, 4, 6, 18)
 
     def test_open_multiples_files(self):
-        self.assertTrue(not self.ds.dataset is [])
+        self.assertTrue(self.ds.dataset)
 
     def test_variables_test(self):
         self.assertEqual(sorted(self.ds.dataset[0].keys()), self.expected_variables,
                          'incorrect number of variables')
 
     def test_variables_rename(self):
-        self.assertFalse(list(self.ds.dataset[0].keys()) in self.expected_variables,
-                         'variable rename fail')
+        self.assertIn('t2m', self.ds.dataset[0], 'variable rename fail')
+        self.assertNotIn('t', self.ds.dataset[0], 'old variable name was not removed')
 
     def test_varible_dimension(self):
         self.assertEqual(self.ds.dataset[0].get('u').isobaricInhPa.value.shape, self.expected_dim,
@@ -82,8 +82,8 @@ class TestNcFiles(unittest.TestCase):
                              'incorrect time cut')
 
     def test_missing_time(self):
-        self.assertTrue(self.missing_time in self.ds.dataset[0].get('time'),
-                             'incorrect time cut')
+        self.assertIn(self.missing_time[0], list(self.ds.dataset[0].get('time')),
+                              'incorrect time cut')
 
     def test_interpolation(self):
         a = self.ds.dataset[0].get('u').isobaricInhPa.value[0, 2, -1].flatten()

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -3,6 +3,7 @@ from gdio.grib import grib
 import os
 import sys
 import numpy as np
+import tempfile
 import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -14,6 +15,9 @@ class TestGribFiles(unittest.TestCase):
     def setUpClass(self):
 
         root = os.path.abspath(os.path.join(os.path.dirname(__file__), "."))
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addClassCleanup(self.tmpdir.cleanup)
+        tmp_grib = os.path.join(self.tmpdir.name, 'tmp.grib')
 
         gr = grib(verbose=False)
         self.gbr = gr.gb_load(os.path.join(root, 'data/era5_20191226-27_lev.grib'),
@@ -22,15 +26,13 @@ class TestGribFiles(unittest.TestCase):
                               rename_vars={'t': '2t'})
 
         # write new grib
-        gr.gb_write(os.path.join(root, 'tmp.grib'), self.gbr,
+        gr.gb_write(tmp_grib, self.gbr,
                     least_significant_digit=3,
                     packingType='grid_jpeg')
 
         # open new new grib
-        self.new_gbr = gr.gb_load(os.path.join(root, 'tmp.grib'),
-                              rename_vars={'t': '2t'})
-
-        os.remove(os.path.join(root, 'tmp.grib'))
+        self.new_gbr = gr.gb_load(tmp_grib,
+                               rename_vars={'t': '2t'})
 
 
 
@@ -47,7 +49,7 @@ class TestGribFiles(unittest.TestCase):
 
     def test_open_grib(self):
 
-        self.assertTrue(not self.gbr is {})
+        self.assertTrue(self.gbr)
 
     def test_variables(self):
         self.assertEqual(sorted(self.gbr.keys()), self.expected_variables,

--- a/tests/test_grib_namespace.py
+++ b/tests/test_grib_namespace.py
@@ -1,0 +1,15 @@
+import unittest
+
+from gdio.definitions.grib_namespace import DATA_TIME_KEYS
+
+
+class TestGribNamespace(unittest.TestCase):
+
+    def test_validity_and_unit_time_keys_are_separate(self):
+        self.assertIn('validityTime', DATA_TIME_KEYS)
+        self.assertIn('unitOfTimeRange', DATA_TIME_KEYS)
+        self.assertNotIn('validityTimeunitOfTimeRange', DATA_TIME_KEYS)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_grib_time.py
+++ b/tests/test_grib_time.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+import importlib
+import sys
+import types
+import unittest
+
+
+class TestGribTime(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._sentinel = object()
+        cls._module_names = ['eccodes', 'numpy', 'pyproj', 'gdio.commons', 'gdio.cgrib', 'gdio.grib']
+        cls._saved_modules = {
+            name: sys.modules.get(name, cls._sentinel)
+            for name in cls._module_names
+        }
+
+        for name in cls._module_names:
+            sys.modules.pop(name, None)
+
+        fake_eccodes = types.ModuleType('eccodes')
+        fake_eccodes.CODES_PRODUCT_GRIB = 1
+        fake_eccodes.KeyValueNotFoundError = type('KeyValueNotFoundError', (Exception,), {})
+        fake_eccodes.ArrayTooSmallError = type('ArrayTooSmallError', (Exception,), {})
+        fake_numpy = types.ModuleType('numpy')
+        fake_pyproj = types.ModuleType('pyproj')
+
+        for name in [
+            'codes_get_native_type',
+            'codes_get_string',
+            'codes_get_double',
+            'codes_get_array',
+            'codes_get',
+            'codes_get_values',
+            'codes_get_message',
+            'codes_count_in_file',
+            'codes_clone',
+            'codes_set',
+            'codes_set_values',
+            'codes_grib_new_from_file',
+            'codes_release',
+            'codes_write',
+            'codes_new_from_samples',
+        ]:
+            setattr(fake_eccodes, name, lambda *args, **kwargs: None)
+
+        sys.modules['eccodes'] = fake_eccodes
+        sys.modules['numpy'] = fake_numpy
+        sys.modules['pyproj'] = fake_pyproj
+        cls.grib_module = importlib.import_module('gdio.grib')
+
+    @classmethod
+    def tearDownClass(cls):
+        for name in cls._module_names:
+            sys.modules.pop(name, None)
+
+            original = cls._saved_modules[name]
+            if original is not cls._sentinel:
+                sys.modules[name] = original
+
+    def test_forecast_step_respects_grib_day_units(self):
+        gb = self.grib_module.grib(verbose=False)
+
+        self.assertEqual(
+            gb._grib__forecast_step(datetime(2020, 1, 3), datetime(2020, 1, 1), 2),
+            2,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -3,6 +3,7 @@ from gdio.hdf import hdf
 import os
 import sys
 import numpy as np
+import tempfile
 import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "")))
@@ -13,6 +14,9 @@ class TestNcFiles(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         root = os.path.abspath(os.path.join(os.path.dirname(__file__), "."))
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addClassCleanup(self.tmpdir.cleanup)
+        tmp_hdf = os.path.join(self.tmpdir.name, 'tmp.hdf')
 
         hd = hdf()
         self.hd = hd.hdf_load(os.path.join(root, 'data/era5_2019122712_lev.hdf'),
@@ -22,12 +26,10 @@ class TestNcFiles(unittest.TestCase):
                              )
 
         # write new hdf
-        hd.hdf_write(os.path.join(root, 'tmp.hdf'), self.hd)
+        hd.hdf_write(tmp_hdf, self.hd)
 
         # open new hdf
-        self.new_hd = hd.hdf_load(os.path.join(root, 'tmp.hdf'))
-
-        os.remove(os.path.join(root, 'tmp.hdf'))
+        self.new_hd = hd.hdf_load(tmp_hdf)
 
 
     def setUp(self):
@@ -41,7 +43,7 @@ class TestNcFiles(unittest.TestCase):
 
 
     def test_open_hdf5(self):
-        self.assertTrue(not self.hd is {})
+        self.assertTrue(self.hd)
 
     def test_variables_test(self):
         self.assertEqual(sorted(list(self.hd.keys())), self.expected_variables,
@@ -94,4 +96,3 @@ class TestNcFiles(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -3,6 +3,7 @@ from gdio.netcdf import netcdf
 import os
 import sys
 import numpy as np
+import tempfile
 import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -13,6 +14,9 @@ class TestNcFiles(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         root = os.path.abspath(os.path.join(os.path.dirname(__file__), "."))
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addClassCleanup(self.tmpdir.cleanup)
+        tmp_nc = os.path.join(self.tmpdir.name, 'tmp.nc')
 
         nc = netcdf()
         self.nc = nc.nc_load(os.path.join(root, 'data/era5_20191227_lev.nc'),
@@ -21,12 +25,10 @@ class TestNcFiles(unittest.TestCase):
                              rename_vars={'t': 't2m'})
 
         # write new nc
-        nc.nc_write(os.path.join(root, 'tmp.nc'), self.nc, global_atrib={'source': 'ecmwf/era5'})
+        nc.nc_write(tmp_nc, self.nc, global_atrib={'source': 'ecmwf/era5'})
 
         # open new nc
-        self.new_nc = nc.nc_load(os.path.join(root, 'tmp.nc'))
-
-        os.remove(os.path.join(root, 'tmp.nc'))
+        self.new_nc = nc.nc_load(tmp_nc)
 
 
     def setUp(self):
@@ -40,7 +42,7 @@ class TestNcFiles(unittest.TestCase):
 
 
     def test_open_netcdf(self):
-        self.assertTrue(not self.nc is {})
+        self.assertTrue(self.nc)
 
     def test_variables_test(self):
         self.assertEqual(sorted(list(self.nc.keys())), self.expected_variables,
@@ -94,7 +96,6 @@ class TestNcFiles(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
 
 
 

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+import importlib
+import importlib.util
+import sys
+import types
+import unittest
+
+
+class TestTimeUtils(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._sentinel = object()
+        cls._saved_modules = {
+            name: sys.modules.get(name, cls._sentinel)
+            for name in ['numpy', 'gdio.commons']
+        }
+
+        sys.modules.pop('gdio.commons', None)
+
+        if importlib.util.find_spec('numpy') is None:
+            sys.modules['numpy'] = types.ModuleType('numpy')
+
+        cls.commons = importlib.import_module('gdio.commons')
+
+    @classmethod
+    def tearDownClass(cls):
+        for name in ['gdio.commons', 'numpy']:
+            sys.modules.pop(name, None)
+
+            original = cls._saved_modules[name]
+            if original is not cls._sentinel:
+                sys.modules[name] = original
+
+    def test_time_unit_to_hours(self):
+        self.assertEqual(self.commons.time_unit_to_hours('seconds'), 1 / 3600)
+        self.assertEqual(self.commons.time_unit_to_hours('minutes'), 1 / 60)
+        self.assertEqual(self.commons.time_unit_to_hours('hours'), 1)
+        self.assertEqual(self.commons.time_unit_to_hours('days'), 24)
+        self.assertEqual(self.commons.time_unit_to_hours('months'), 24 * 30)
+        self.assertEqual(self.commons.time_unit_to_hours('years'), 24 * 365)
+
+    def test_parse_time_units(self):
+        unit, ref_time = self.commons.parse_time_units('hours since 2019-12-27 12:30')
+
+        self.assertEqual(unit, 'hours')
+        self.assertEqual(ref_time, datetime(2019, 12, 27, 12, 30))
+
+    def test_parse_invalid_time_units(self):
+        self.assertEqual(self.commons.parse_time_units('not a time unit'), (None, None))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- align Python support around >=3.9 and fix Docker version mismatch
- add Docker context hardening and run container as non-root
- remove tracked __pycache__ artifacts
- fix GRIB time/key handling and projection writer bug
- fix time-unit conversion, resource cleanup, and mutable defaults
- harden HDF iteration against external links
- respect nc_write zlib option
- improve tests and use temp dirs for generated files
- document the audit and remaining risks in docs/